### PR TITLE
Properly set background color when opening new page

### DIFF
--- a/R/SVG.R
+++ b/R/SVG.R
@@ -1,15 +1,13 @@
-#' A SVG Graphics Driver
+#' An SVG Graphics Driver
 #'
-#' This function produces graphics suitable the current w3 svg XML standard.
-#' It currently does not have any font metric information, so the use of
-#' \code{\link{plotmath}} is not supported. The driver output is currently NOT
-#' specifying a DOCTYPE DTD
+#' This function produces graphics compliant to the current w3 svg XML standard.
+#' The driver output is currently NOT specifying a DOCTYPE DTD.
 #'
 #' @param file the file where output will appear.
 #' @param height,width Height and width in inches.
 #' @param bg Default background color for the plot (defaults to "white").
 #' @param pointsize default point size.
-#' @param standalone Produce a stand alone svg file? If \code{FALSE}, omits
+#' @param standalone Produce a standalone svg file? If \code{FALSE}, omits
 #'   xml header and default namespace.
 #' @references \emph{W3C Scalable Vector Graphics (SVG)}:
 #'   \url{http://www.w3.org/Graphics/SVG/Overview.htm8}

--- a/R/inlineSVG.R
+++ b/R/inlineSVG.R
@@ -4,7 +4,7 @@
 #' package.
 #'
 #' @param code Plotting code to execute.
-#' @param ... Other arguments passed on to \code{\link{devSVG}}.
+#' @param ... Other arguments passed on to \code{\link{svglite}}.
 #' @export
 #' @examples
 #' if (require("htmltools")) {

--- a/man/editSVG.Rd
+++ b/man/editSVG.Rd
@@ -9,7 +9,7 @@ editSVG(code, ...)
 \arguments{
 \item{code}{Plotting code to execute.}
 
-\item{...}{Other arguments passed on to \code{\link{devSVG}}.}
+\item{...}{Other arguments passed on to \code{\link{svglite}}.}
 }
 \description{
 This is useful primarily for testing or post-processing the SVG.

--- a/man/htmlSVG.Rd
+++ b/man/htmlSVG.Rd
@@ -9,7 +9,7 @@ htmlSVG(code, ...)
 \arguments{
 \item{code}{Plotting code to execute.}
 
-\item{...}{Other arguments passed on to \code{\link{devSVG}}.}
+\item{...}{Other arguments passed on to \code{\link{svglite}}.}
 }
 \description{
 This is useful primarily for testing. Requires the \code{htmltools}

--- a/man/svglite.Rd
+++ b/man/svglite.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/SVG.R
 \name{svglite}
 \alias{svglite}
-\title{A SVG Graphics Driver}
+\title{An SVG Graphics Driver}
 \usage{
 svglite(file = "Rplots.svg", width = 10, height = 8, bg = "white",
   pointsize = 12, standalone = TRUE)
@@ -16,14 +16,12 @@ svglite(file = "Rplots.svg", width = 10, height = 8, bg = "white",
 
 \item{pointsize}{default point size.}
 
-\item{standalone}{Produce a stand alone svg file? If \code{FALSE}, omits
+\item{standalone}{Produce a standalone svg file? If \code{FALSE}, omits
 xml header and default namespace.}
 }
 \description{
-This function produces graphics suitable the current w3 svg XML standard.
-It currently does not have any font metric information, so the use of
-\code{\link{plotmath}} is not supported. The driver output is currently NOT
-specifying a DOCTYPE DTD
+This function produces graphics compliant to the current w3 svg XML standard.
+The driver output is currently NOT specifying a DOCTYPE DTD.
 }
 \examples{
 svglite()

--- a/man/xmlSVG.Rd
+++ b/man/xmlSVG.Rd
@@ -9,9 +9,9 @@ xmlSVG(code, ..., standalone = FALSE)
 \arguments{
 \item{code}{Plotting code to execute.}
 
-\item{...}{Other arguments passed on to \code{\link{devSVG}}.}
+\item{...}{Other arguments passed on to \code{\link{svglite}}.}
 
-\item{standalone}{Produce a stand alone svg file? If \code{FALSE}, omits
+\item{standalone}{Produce a standalone svg file? If \code{FALSE}, omits
 xml header and default namespace.}
 }
 \value{

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -268,11 +268,13 @@ void svg_new_page(const pGEcontext gc, pDevDesc dd) {
   fputs("</defs>\n", svgd->file);
 
   fputs("<rect width='100%' height='100%'", svgd->file);
-  if (is_filled(gc->fill)) {
-    write_style_begin(svgd->file);
-    write_style_col(svgd->file, "fill", gc->fill, true);
-    write_style_end(svgd->file);
-  }
+  write_style_begin(svgd->file);
+  write_style_str(svgd->file, "stroke", "none", true);
+  if (is_filled(gc->fill))
+    write_style_col(svgd->file, "fill", gc->fill);
+  else
+    write_style_col(svgd->file, "fill", dd->startfill);
+  write_style_end(svgd->file);
   fputs("/>\n", svgd->file);
 
   svgd->pageno++;

--- a/tests/testthat/test-devSVG.R
+++ b/tests/testthat/test-devSVG.R
@@ -13,6 +13,11 @@ test_that("adds default background", {
   expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), "#FFFFFF")
 })
 
+test_that("adds background set by device driver", {
+  x <- xmlSVG(plot.new(), bg = "red")
+  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), rgb(1, 0, 0))
+})
+
 test_that("default background respects par", {
   x <- xmlSVG({
     par(bg = "red")
@@ -21,14 +26,14 @@ test_that("default background respects par", {
   expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), rgb(1, 0, 0))
 })
 
-test_that("no background", {
+test_that("if bg is transparent in par(), use device driver background", {
   x <- xmlSVG({
     par(bg = NA)
     plot.new()
-  })
+  }, bg = "blue")
   style <- xml_text(xml_find_one(x, "//style"))
   expect_match(style, "fill: none;")
-  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), NA_character_)
+  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), rgb(0, 0, 1))
 })
 
 test_that("can only have one page", {


### PR DESCRIPTION
The background of the SVG file will be determined by the following rules:

1. No stroke
2. If `par("bg")` is transparent, use the background color specified in `svglite(.., bg = ...)`
3. If `par("bg")` is not transparent, use it as the background color