### PR TITLE
removes path argument from `inlineSVG` and adds path to editSVG

### DIFF
--- a/R/inlineSVG.R
+++ b/R/inlineSVG.R
@@ -42,20 +42,21 @@ xmlSVG <- function(code, ... , standalone = FALSE) {
 #' This is useful primarily for testing or post-processing the SVG.
 #'
 #' @inheritParams htmlSVG
+#' @param path \code{string} Name of the file to create.  The default
+#'          behavior will be to create a \code{tempfile}.
 #' @export
 #' @examples
 #' if (interactive()) {
 #'   editSVG(plot(1:10))
 #'   editSVG(contour(volcano))
 #' }
-editSVG <- function(code, ...) {
-  tmp <- inlineSVG(code, ...)
-  system(sprintf("open %s", shQuote(tmp)))
+editSVG <- function(code, path = tempfile(fileext = ".svg"), ...) {
+  cat(inlineSVG(code, ...), file=path)
+  system(sprintf("open %s", shQuote(path)))
 }
 
 
-inlineSVG <- function(code, ..., width = NA, height = NA,
-                      path = tempfile(fileext = ".svg")) {
+inlineSVG <- function(code, ..., width = NA, height = NA) {
   dim <- plot_dim(c(width, height))
 
   svg <- svgstring(width = dim[1], height = dim[2], ...)

--- a/R/inlineSVG.R
+++ b/R/inlineSVG.R
@@ -42,8 +42,8 @@ xmlSVG <- function(code, ... , standalone = FALSE) {
 #' This is useful primarily for testing or post-processing the SVG.
 #'
 #' @inheritParams htmlSVG
-#' @param path \code{string} Name of the file to create.  The default
-#'          behavior will be to create a \code{tempfile}.
+#' @param path Name of the file to save.  The default behavior
+#'          will be to create a temporary file with extension \code{.svg}.
 #' @export
 #' @examples
 #' if (interactive()) {


### PR DESCRIPTION
Attempts to fix #56 by removing the no longer necessary `path` argument from `inlineSVG`.  Also, since a file is no longer created by `inlineSVG`, add a `path` argument to `editSVG` since it requires a file to work correctly.