### PR TITLE
issue #60: adjustcolor alpha.f has no effect on svglite output

### DIFF
--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -49,7 +49,7 @@ public:
 };
 
 inline bool is_black(int col) {
-  return (R_RED(col) == 0) && (R_GREEN(col) == 0) && (R_BLUE(col) == 0) && (R_ALPHA(col) == 1);
+  return (R_RED(col) == 0) && (R_GREEN(col) == 0) && (R_BLUE(col) == 0) && (R_ALPHA(col) == 255);
 }
 
 inline bool is_filled(int col) {

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -49,7 +49,7 @@ public:
 };
 
 inline bool is_black(int col) {
-  return (R_RED(col) == 0) && (R_GREEN(col) == 0) && (R_BLUE(col) == 0);
+  return (R_RED(col) == 0) && (R_GREEN(col) == 0) && (R_BLUE(col) == 0) && (R_ALPHA(col) == 1);
 }
 
 inline bool is_filled(int col) {

--- a/tests/testthat/test-clip.svg
+++ b/tests/testthat/test-clip.svg
@@ -23,7 +23,7 @@
     <rect x='158.40' y='64.80' width='72.00' height='72.00' />
   </clipPath>
 </defs>
-<g clip-path='url(#cp2)'><text transform='translate(112.47,136.88) rotate(-30)' style='font-size: 24.00pt; font-family: Arial;'>Clipping</text></g>
+<g clip-path='url(#cp2)'><text transform='translate(112.47,136.87) rotate(-30)' style='font-size: 24.00pt; font-family: Arial;'>Clipping</text></g>
 <defs>
   <clipPath id='cp3'>
     <rect x='86.40' y='64.80' width='72.00' height='72.00' />

--- a/tests/testthat/test-no-clip.svg
+++ b/tests/testthat/test-no-clip.svg
@@ -18,6 +18,6 @@
   </clipPath>
 </defs>
 <rect x='122.40' y='100.80' width='72.00' height='72.00' style='stroke-width: 0.75; fill: #0000FF;' clip-path='url(#cp1)' />
-<g clip-path='url(#cp1)'><text transform='translate(112.47,136.88) rotate(-30)' style='font-size: 24.00pt; font-family: Arial;'>Clipping</text></g>
+<g clip-path='url(#cp1)'><text transform='translate(112.47,136.87) rotate(-30)' style='font-size: 24.00pt; font-family: Arial;'>Clipping</text></g>
 <line x1='59.04' y1='100.80' x2='257.76' y2='100.80' style='stroke-width: 0.75; stroke: #FF0000;' clip-path='url(#cp1)' />
 </svg>

--- a/tests/testthat/test-text.R
+++ b/tests/testthat/test-text.R
@@ -129,3 +129,25 @@ test_that("strwidth and height correctly computed", {
 
   rect(0.5 - w / 2, 0.5 - h / 2, 0.5 + w / 2, 0.5 + h / 2)
 })
+
+test_that("Black text uses default fill", {
+  x <- xmlSVG({
+    plot.new()
+    text(0.5, 0.1, "a", col=rgb(0, 0, 0))
+  })
+  text <- xml_find_all(x, ".//text")
+  expect_equal(style_attr(text, "fill"), NA_character_)
+})
+
+test_that("Text with alpha sets fill", {
+  x <- xmlSVG({
+    plot.new()
+    text(0.5, 0.1, "a", col=rgb(0, 0, 0, 0.6))
+    text(0.5, 0.1, "b", col=rgb(0, 0, 0, 0.5))
+    text(0.5, 0.1, "c", col=rgb(0.5, 0.5, 0.5, 0.5))
+    text(0.5, 0.1, "c", col=rgb(0.5, 0.5, 0.5, 1))
+  })
+  text <- xml_find_all(x, ".//text")
+  expect_equal(style_attr(text, "fill"), c("#000000", "#000000", "#808080", "#808080"))
+  expect_equal(style_attr(text, "fill-opacity"), c("0.60", "0.50", "0.50", NA_character_))
+})

--- a/tests/testthat/test-text.svg
+++ b/tests/testthat/test-text.svg
@@ -17,6 +17,6 @@
     <rect x='59.04' y='59.04' width='198.72' height='155.52' />
   </clipPath>
 </defs>
-<g clip-path='url(#cp1)'><text x='106.83' y='140.84' style='font-size: 12.00pt; font-family: Arial;'>This is a string</text></g>
-<rect x='106.83' y='131.07' width='103.14' height='11.45' style='stroke-width: 0.75;' clip-path='url(#cp1)' />
+<g clip-path='url(#cp1)'><text x='106.83' y='140.95' style='font-size: 12.00pt; font-family: Arial;'>This is a string</text></g>
+<rect x='106.83' y='131.30' width='103.14' height='11.00' style='stroke-width: 0.75;' clip-path='url(#cp1)' />
 </svg>


### PR DESCRIPTION
Added in the alpha channel information to is_black(). It was only checking the red/green/blue channels, so any black with alpha was being treated as pure black.