### PR TITLE
The checks for NA_INTEGER are unnecessary. The value of NA_INTEGER is…

### DIFF
--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -54,7 +54,7 @@ inline bool is_black(int col) {
 
 inline bool is_filled(int col) {
   const int alpha = R_ALPHA(col);
-  return (col != NA_INTEGER) && (alpha != 0);
+  return (alpha != 0);
 }
 
 inline bool is_bold(int face) {
@@ -122,7 +122,7 @@ inline void write_style_col(SvgStreamPtr stream, const char* attr, int col, bool
 
   if(!first)  (*stream) << ' ';
 
-  if (col == NA_INTEGER || alpha == 0) {
+  if (alpha == 0) {
     (*stream) << attr << ": none;";
     return;
   } else {


### PR DESCRIPTION
… a valid colour (#00000080). NA values for colour have already been converted to completely transparent white (#ffffff00) before reaching svglite.

See `R_ext/GraphicsDevice.h` where it says:
```
/*
 * Changes as from 2.0.0:  use top 8 bits as full alpha channel
 *      255 = opaque, 0 = transparent
 *      [to conform with SVG, PDF and others]
 *      and everything in between is used
 *      [which means that NA is not stored as an internal colour;
 *       it is converted to R_RGBA(255, 255, 255, 0)]
 */
```

So a check for `NA_INTEGER` on a colour is meaningless since it will match a different colour (#00000080)