### PR TITLE
Use xml2::xml_find_first() instead of deprecated xml2::xml_find_one()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,6 +29,7 @@ Suggests:
     testthat,
     xml2,
     covr
+Remotes: hadley/xml2
 License: GPL (>= 2)
 URL: https://github.com/hadley/svglite
 BugReports: https://github.com/hadley/svglite/issues

--- a/tests/testthat/test-devSVG.R
+++ b/tests/testthat/test-devSVG.R
@@ -10,12 +10,12 @@ style_attr <- function(nodes, attr) {
 
 test_that("adds default background", {
   x <- xmlSVG(plot.new())
-  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), "#FFFFFF")
+  expect_equal(style_attr(xml_find_first(x, ".//rect"), "fill"), "#FFFFFF")
 })
 
 test_that("adds background set by device driver", {
   x <- xmlSVG(plot.new(), bg = "red")
-  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), rgb(1, 0, 0))
+  expect_equal(style_attr(xml_find_first(x, ".//rect"), "fill"), rgb(1, 0, 0))
 })
 
 test_that("default background respects par", {
@@ -23,7 +23,7 @@ test_that("default background respects par", {
     par(bg = "red")
     plot.new()
   })
-  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), rgb(1, 0, 0))
+  expect_equal(style_attr(xml_find_first(x, ".//rect"), "fill"), rgb(1, 0, 0))
 })
 
 test_that("if bg is transparent in par(), use device driver background", {
@@ -31,9 +31,9 @@ test_that("if bg is transparent in par(), use device driver background", {
     par(bg = NA)
     plot.new()
   }, bg = "blue")
-  style <- xml_text(xml_find_one(x, "//style"))
+  style <- xml_text(xml_find_first(x, "//style"))
   expect_match(style, "fill: none;")
-  expect_equal(style_attr(xml_find_one(x, ".//rect"), "fill"), rgb(0, 0, 1))
+  expect_equal(style_attr(xml_find_first(x, ".//rect"), "fill"), rgb(0, 0, 1))
 })
 
 test_that("can only have one page", {

--- a/tests/testthat/test-lines.R
+++ b/tests/testthat/test-lines.R
@@ -13,9 +13,9 @@ test_that("segments don't have fill", {
     plot.new()
     segments(0.5, 0.5, 1, 1)
   })
-  style <- xml_text(xml_find_one(x, "//style"))
+  style <- xml_text(xml_find_first(x, "//style"))
   expect_match(style, "fill: none;")
-  expect_equal(style_attr(xml_find_one(x, ".//line"), "fill"), NA_character_)
+  expect_equal(style_attr(xml_find_first(x, ".//line"), "fill"), NA_character_)
 })
 
 test_that("lines don't have fill", {
@@ -23,7 +23,7 @@ test_that("lines don't have fill", {
     plot.new()
     lines(c(0.5, 1, 0.5), c(0.5, 1, 1))
   })
-  expect_equal(style_attr(xml_find_one(x, ".//polyline"), "fill"), NA_character_)
+  expect_equal(style_attr(xml_find_first(x, ".//polyline"), "fill"), NA_character_)
 })
 
 test_that("polygons do have fill", {
@@ -31,7 +31,7 @@ test_that("polygons do have fill", {
     plot.new()
     polygon(c(0.5, 1, 0.5), c(0.5, 1, 1), col = "red", border = "blue")
   })
-  polygon <- xml_find_one(x, ".//polyline")
+  polygon <- xml_find_first(x, ".//polyline")
   expect_equal(style_attr(polygon, "fill"), rgb(1, 0, 0))
   expect_equal(style_attr(polygon, "stroke"), rgb(0, 0, 1))
 })
@@ -41,7 +41,7 @@ test_that("polygons without border", {
     plot.new()
     polygon(c(0.5, 1, 0.5), c(0.5, 1, 1), col = "red", border = NA)
   })
-  polygon <- xml_find_one(x, ".//polyline")
+  polygon <- xml_find_first(x, ".//polyline")
   expect_equal(style_attr(polygon, "fill"), rgb(1, 0, 0))
   expect_equal(style_attr(polygon, "stroke"), "none")
 })
@@ -51,7 +51,7 @@ test_that("last point of polygon joined to first point", {
     plot.new()
     polygon(c(0.5, 1, 0.5), c(0, 1, 1))
   })
-  points <- strsplit(xml_attr(xml_find_one(x, ".//polyline"), "points"), " ")[[1]]
+  points <- strsplit(xml_attr(xml_find_first(x, ".//polyline"), "points"), " ")[[1]]
   expect_equal(length(points), 4)
 })
 
@@ -62,7 +62,7 @@ test_that("blank lines are omitted", {
 
 dash_array <- function(...) {
   x <- xmlSVG(mini_plot(1:3, ..., type = "l"))
-  dash <- style_attr(xml_find_one(x, "//polyline"), "stroke-dasharray")
+  dash <- style_attr(xml_find_first(x, "//polyline"), "stroke-dasharray")
   as.integer(strsplit(dash, ",")[[1]])
 }
 
@@ -95,11 +95,11 @@ test_that("line end shapes", {
     plot.new()
     lines(c(0.3, 0.7), c(0.5, 0.5), lwd = 15, lend = "square")
   })
-  style <- xml_text(xml_find_one(x1, "//style"))
+  style <- xml_text(xml_find_first(x1, "//style"))
   expect_match(style, "stroke-linecap: round;")
-  expect_equal(style_attr(xml_find_one(x1, ".//polyline"), "stroke-linecap"), NA_character_)
-  expect_equal(style_attr(xml_find_one(x2, ".//polyline"), "stroke-linecap"), "butt")
-  expect_equal(style_attr(xml_find_one(x3, ".//polyline"), "stroke-linecap"), "square")
+  expect_equal(style_attr(xml_find_first(x1, ".//polyline"), "stroke-linecap"), NA_character_)
+  expect_equal(style_attr(xml_find_first(x2, ".//polyline"), "stroke-linecap"), "butt")
+  expect_equal(style_attr(xml_find_first(x3, ".//polyline"), "stroke-linecap"), "square")
 })
 
 test_that("line join shapes", {
@@ -119,7 +119,7 @@ test_that("line join shapes", {
     plot.new()
     lines(c(0.3, 0.5, 0.7), c(0.1, 0.9, 0.1), lwd = 15, ljoin = "bevel")
   })
-  style <- xml_text(xml_find_one(x1, "//style"))
+  style <- xml_text(xml_find_first(x1, "//style"))
   expect_match(style, "stroke-linejoin: round;")
   expect_match(style, "stroke-miterlimit: 10.00;")
   expect_equal(style_attr(xml_find_all(x1, ".//polyline"), "stroke-linejoin"), NA_character_)

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -16,7 +16,7 @@ test_that("paths with winding fill mode", {
              col = rgb(0.5, 0.5, 0.5, 0.3), border = rgb(1, 0, 0, 0.3),
              rule = "winding")
   })
-  path <- xml_find_one(x, ".//path")
+  path <- xml_find_first(x, ".//path")
   expect_equal(style_attr(path, "fill-rule"), "nonzero")
   expect_equal(style_attr(path, "fill"), rgb(0.5, 0.5, 0.5))
   expect_equal(style_attr(path, "fill-opacity"), "0.30")
@@ -32,7 +32,7 @@ test_that("paths with evenodd fill mode", {
              col = rgb(0.5, 0.5, 0.5, 0.3), border = rgb(1, 0, 0, 0.3),
              rule = "evenodd")
   })
-  path <- xml_find_one(x, ".//path")
+  path <- xml_find_first(x, ".//path")
   expect_equal(style_attr(path, "fill-rule"), "evenodd")
   expect_equal(style_attr(path, "fill"), rgb(0.5, 0.5, 0.5))
   expect_equal(style_attr(path, "fill-opacity"), "0.30")
@@ -48,10 +48,10 @@ test_that("paths with no filling color", {
              col = NA, border = rgb(1, 0, 0, 0.3),
              rule = "winding")
   })
-  style <- xml_text(xml_find_one(x, "//style"))
+  style <- xml_text(xml_find_first(x, "//style"))
   expect_match(style, "fill: none;")
 
-  path <- xml_find_one(x, ".//path")
+  path <- xml_find_first(x, ".//path")
   expect_equal(style_attr(path, "fill-rule"), "nonzero")
   expect_equal(style_attr(path, "fill"), NA_character_)
   expect_equal(style_attr(path, "stroke"), rgb(1, 0, 0))

--- a/tests/testthat/test-points.R
+++ b/tests/testthat/test-points.R
@@ -45,7 +45,7 @@ test_that("points are given stroke and fill", {
     plot.new()
     points(0.5, 0.5, pch = 21, col = "red", bg = NA, cex = 20)
   })
-  style <- xml_text(xml_find_one(x, "//style"))
+  style <- xml_text(xml_find_first(x, "//style"))
   expect_match(style, "fill: none;")
 
   circle <- xml_find_all(x, ".//circle")

--- a/tests/testthat/test-text.R
+++ b/tests/testthat/test-text.R
@@ -37,7 +37,7 @@ test_that("special characters are escaped", {
   })
   # xml_text unescapes for us - this still tests that the
   # file parses, which it wouldn't otherwise
-  expect_equal(xml_text(xml_find_one(x, ".//text")), "<&>")
+  expect_equal(xml_text(xml_find_first(x, ".//text")), "<&>")
 })
 
 test_that("utf-8 characters are preserved", {
@@ -49,7 +49,7 @@ test_that("utf-8 characters are preserved", {
   })
   # xml_text unescapes for us - this still tests that the
   # file parses, which it wouldn't otherwise
-  expect_equal(xml_text(xml_find_one(x, ".//text")), "\u00b5")
+  expect_equal(xml_text(xml_find_first(x, ".//text")), "\u00b5")
 })
 
 test_that("special characters are escaped", {
@@ -59,7 +59,7 @@ test_that("special characters are escaped", {
   })
   # xml_text unescapes for us - this still tests that the
   # file parses, which it wouldn't otherwise
-  expect_equal(style_attr(xml_find_one(x, ".//text"), "fill"), "#113399")
+  expect_equal(style_attr(xml_find_first(x, ".//text"), "fill"), "#113399")
 })
 
 test_that("default point size is 12", {
@@ -67,7 +67,7 @@ test_that("default point size is 12", {
     plot.new()
     text(0.5, 0.5, "a")
   })
-  expect_equal(style_attr(xml_find_one(x, ".//text"), "font-size"), "12.00pt")
+  expect_equal(style_attr(xml_find_first(x, ".//text"), "font-size"), "12.00pt")
 })
 
 test_that("cex generates fractional font sizes", {
@@ -75,7 +75,7 @@ test_that("cex generates fractional font sizes", {
     plot.new()
     text(0.5, 0.5, "a", cex = 0.1)
   })
-  expect_equal(style_attr(xml_find_one(x, ".//text"), "font-size"), "1.20pt")
+  expect_equal(style_attr(xml_find_first(x, ".//text"), "font-size"), "1.20pt")
 })
 
 test_that("font sets weight/style", {


### PR DESCRIPTION
The next version of xml2 will be deprecating xml_find_one() in favor of
xml_find_first(). The new function is a drop in replacement for the old, and no
longer issues a warning when more than one result would be returned.

This pull request also adds a `Remotes: hadley/xml2` entry to install the
development version of xml2. Once the new version of xml2 is released (2-4
weeks) this should be removed.