### PR TITLE
Improve the performance of svgstring()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -6,7 +6,9 @@
 
 * `editSVG()` works again (#56).
 
-* Transparent blacks are written correctly (#62, #63). 
+* Transparent blacks are written correctly (#62, #63).
+
+* Greatly improves the performance of `svgstring()` (#58).
 
 # svglite 1.1.0
 

--- a/R/RcppExports.R
+++ b/R/RcppExports.R
@@ -9,3 +9,7 @@ svgstring_ <- function(env, bg, width, height, pointsize, standalone) {
     .Call('svglite_svgstring_', PACKAGE = 'svglite', env, bg, width, height, pointsize, standalone)
 }
 
+get_svg_content <- function(p) {
+    .Call('svglite_get_svg_content', PACKAGE = 'svglite', p)
+}
+

--- a/R/SVG.R
+++ b/R/SVG.R
@@ -57,11 +57,11 @@ svgstring <- function(width = 10, height = 8, bg = "white",
                       pointsize = 12, standalone = TRUE) {
 
   env <- new.env(parent = emptyenv())
-  svgstring_(env, width = width, height = height, bg = bg,
+  string_src <- svgstring_(env, width = width, height = height, bg = bg,
     pointsize = pointsize, standalone = standalone)
 
   function() {
-    structure(env$svg_string, class = "svg")
+    structure(get_svg_content(string_src), class = "svg")
   }
 }
 

--- a/R/SVG.R
+++ b/R/SVG.R
@@ -61,7 +61,8 @@ svgstring <- function(width = 10, height = 8, bg = "white",
     pointsize = pointsize, standalone = standalone)
 
   function() {
-    structure(get_svg_content(string_src), class = "svg")
+    svgstr <- if(env$is_closed) env$svg_string else get_svg_content(string_src)
+    structure(svgstr, class = "svg")
   }
 }
 

--- a/src/RcppExports.cpp
+++ b/src/RcppExports.cpp
@@ -22,7 +22,7 @@ BEGIN_RCPP
 END_RCPP
 }
 // svgstring_
-bool svgstring_(Rcpp::Environment env, std::string bg, double width, double height, double pointsize, bool standalone);
+Rcpp::XPtr<std::stringstream> svgstring_(Rcpp::Environment env, std::string bg, double width, double height, double pointsize, bool standalone);
 RcppExport SEXP svglite_svgstring_(SEXP envSEXP, SEXP bgSEXP, SEXP widthSEXP, SEXP heightSEXP, SEXP pointsizeSEXP, SEXP standaloneSEXP) {
 BEGIN_RCPP
     Rcpp::RObject __result;
@@ -34,6 +34,17 @@ BEGIN_RCPP
     Rcpp::traits::input_parameter< double >::type pointsize(pointsizeSEXP);
     Rcpp::traits::input_parameter< bool >::type standalone(standaloneSEXP);
     __result = Rcpp::wrap(svgstring_(env, bg, width, height, pointsize, standalone));
+    return __result;
+END_RCPP
+}
+// get_svg_content
+std::string get_svg_content(Rcpp::XPtr<std::stringstream> p);
+RcppExport SEXP svglite_get_svg_content(SEXP pSEXP) {
+BEGIN_RCPP
+    Rcpp::RObject __result;
+    Rcpp::RNGScope __rngScope;
+    Rcpp::traits::input_parameter< Rcpp::XPtr<std::stringstream> >::type p(pSEXP);
+    __result = Rcpp::wrap(get_svg_content(p));
     return __result;
 END_RCPP
 }

--- a/src/SvgStream.h
+++ b/src/SvgStream.h
@@ -79,20 +79,17 @@ public:
   void write(char data)               { stream_ << data; }
   void write(const std::string& data) { stream_ << data; }
 
-  void seek(int n) {
-    stream_.seekg(n, std::ios_base::cur);
-  }
-
   void flush() {
-    stream_.flush();
-    env_["svg_string"] = stream_.str() + "</svg>";
   }
 
   void finish() {
-    flush();
   }
 
-
+  Rcpp::XPtr<std::stringstream> string_src() {
+    // `false` means this pointer should not be "deleted" by R
+    // The object will be automatically destroyed when device is closed
+    return Rcpp::XPtr<std::stringstream>(&stream_, false);
+  }
 };
 
 

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -330,6 +330,7 @@ VOID_END_RCPP
 
 void svg_close(pDevDesc dd) {
   SVGDesc *svgd = (SVGDesc*) dd->deviceSpecific;
+  svgd->stream->finish();
   delete(svgd);
 }
 

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -681,11 +681,25 @@ bool svglite_(std::string file, std::string bg, double width, double height,
 }
 
 // [[Rcpp::export]]
-bool svgstring_(Rcpp::Environment env, std::string bg, double width, double height,
+Rcpp::XPtr<std::stringstream> svgstring_(Rcpp::Environment env, std::string bg, double width, double height,
   double pointsize, bool standalone) {
 
   SvgStreamPtr stream(new SvgStreamString(env));
   makeDevice(stream, bg, width, height, pointsize, standalone);
 
-  return true;
+  SvgStreamString* strstream = static_cast<SvgStreamString*>(stream.get());
+
+  return strstream->string_src();
+}
+
+// [[Rcpp::export]]
+std::string get_svg_content(Rcpp::XPtr<std::stringstream> p) {
+  p->flush();
+  std::string svgstr = p->str();
+  // If the current SVG is empty, we also make the string empty
+  // Otherwise append "</svg>" to make it a valid SVG
+  if(!svgstr.empty()) {
+    svgstr.append("</svg>");
+  }
+  return svgstr;
 }

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -268,6 +268,7 @@ void svg_clip(double x0, double x1, double y0, double y1, pDevDesc dd) {
     "' width='" << std::abs(x1 - x0) << "' height='" << std::abs(y1 - y0) << "' />\n";
   (*stream) << "  </clipPath>\n";
   (*stream) << "</defs>\n";
+  stream->flush();
 }
 
 void svg_new_page(const pGEcontext gc, pDevDesc dd) {
@@ -329,8 +330,6 @@ VOID_END_RCPP
 
 void svg_close(pDevDesc dd) {
   SVGDesc *svgd = (SVGDesc*) dd->deviceSpecific;
-
-  *(svgd->stream) << "</svg>\n";
   delete(svgd);
 }
 

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -349,7 +349,7 @@ void svg_line(double x1, double y1, double x2, double y2,
   write_attr_clip(stream, svgd->clipno);
 
   (*stream) << " />\n";
-  stream->finish();
+  stream->flush();
 }
 
 void svg_poly(int n, double *x, double *y, int filled, const pGEcontext gc,


### PR DESCRIPTION
This PR should greatly improve the performance of svgstring() based on the discussion in #58.

The basic idea is to let `svgstring_` return a pointer of the string buffer, instead of copying the whole string to R every time. When user requests the SVG content, a reader function will be called on the pointer and the string will be retrieved.

When device is closed, the final string will be copied to R, so users can still retrieve the SVG string even if device is closed.

Based on this PR, below is my result for the same test in #58.

```r
system.time({
    fl <- tempfile(fileext=".svg")
    svglite(file = fl)
    plot(runif(10000), 1:10000)
    dev.off()
})
##   user  system elapsed 
##  0.022   0.008   0.029 

system.time({
    svgstring()
    plot(runif(10000), 1:10000)
    dev.off()
})
##   user  system elapsed 
##  0.025   0.001   0.026 
```