### PR TITLE
Apply masks in `svg_use_group()`

### DIFF
--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -1593,13 +1593,15 @@ void svg_use_group(SEXP ref, SEXP trans, pDevDesc dd) {
       REAL(trans)[1] << "," <<
       REAL(trans)[4] << "," <<
       REAL(trans)[2] << "," <<
-      REAL(trans)[5] << ");'>\n";
-  }
-
-  (*stream) << "  <use href='#group-" << key << "' />\n";
-
-  if (has_transform) {
+      REAL(trans)[5] << ");'";
+    write_attr_mask(stream, svgd->current_mask);
+    (*stream) << ">\n";
+    (*stream) << "  <use href='#group-" << key << "' />\n";
     (*stream) << "  </g>\n";
+  } else {
+    (*stream) << "  <use href='#group-" << key << "'";
+    write_attr_mask(stream, svgd->current_mask);
+    (*stream) << " />\n";
   }
 
   return;

--- a/src/devSVG.cpp
+++ b/src/devSVG.cpp
@@ -1586,18 +1586,26 @@ void svg_use_group(SEXP ref, SEXP trans, pDevDesc dd) {
   }
 
   bool has_transform = trans != R_NilValue;
+  bool has_mask = svgd->current_mask >= 0;
   if (has_transform) {
+	// Separate mask onto a wrapper so it resolves in parent coordinate space.
+    if (has_mask) {
+      (*stream) << "  <g";
+      write_attr_mask(stream, svgd->current_mask);
+      (*stream) << ">\n";
+    }
     (*stream) << "  <g style='transform:matrix(" <<
       REAL(trans)[0] << "," <<
       REAL(trans)[3] << "," <<
       REAL(trans)[1] << "," <<
       REAL(trans)[4] << "," <<
       REAL(trans)[2] << "," <<
-      REAL(trans)[5] << ");'";
-    write_attr_mask(stream, svgd->current_mask);
-    (*stream) << ">\n";
+      REAL(trans)[5] << ");'>\n";
     (*stream) << "  <use href='#group-" << key << "' />\n";
     (*stream) << "  </g>\n";
+    if (has_mask) {
+      (*stream) << "  </g>\n";
+    }
   } else {
     (*stream) << "  <use href='#group-" << key << "'";
     write_attr_mask(stream, svgd->current_mask);

--- a/tests/testthat/test-use-group.R
+++ b/tests/testthat/test-use-group.R
@@ -1,0 +1,30 @@
+library(xml2)
+library(grid)
+
+test_that("alpha mask applied to groups", {
+  skip_if_not(getRversion() >= "4.2.0")
+
+  mask <- as.mask(
+    rectGrob(x = 0.5, y = 0.5, width = 0.25, height = 0.25,
+  		   gp = gpar(col = NA, fill = "white")),
+    type = "alpha"
+  )
+
+  # without transform (grid.group)"
+  x_g <- xmlSVG({
+    grid.newpage()
+    grid.group(rectGrob(gp = gpar(col = NA, fill = "blue")),
+               vp = viewport(mask = mask))
+  })
+  use_node <- xml_find_first(x_g, ".//use")
+  expect_equal(xml_attr(use_node, "mask"), "url(#mask-0)")
+
+  # alpha mask applied to group with transform (grid.define/grid.use)
+  x_u <- xmlSVG({
+    grid.newpage()
+    grid.define(rectGrob(gp = gpar(col = NA, fill = "blue")), name = "box")
+    grid.use("box", vp = viewport(mask = mask))
+  })
+  g_node <- xml_find_first(x_u, ".//g[contains(@style,'transform:matrix')]")
+  expect_equal(xml_attr(g_node, "mask"), "url(#mask-0)")
+})

--- a/tests/testthat/test-use-group.R
+++ b/tests/testthat/test-use-group.R
@@ -10,7 +10,7 @@ test_that("alpha mask applied to groups", {
     type = "alpha"
   )
 
-  # without transform (grid.group)"
+  # without transform (grid.group)
   x_g <- xmlSVG({
     grid.newpage()
     grid.group(rectGrob(gp = gpar(col = NA, fill = "blue")),
@@ -19,12 +19,15 @@ test_that("alpha mask applied to groups", {
   use_node <- xml_find_first(x_g, ".//use")
   expect_equal(xml_attr(use_node, "mask"), "url(#mask-0)")
 
-  # alpha mask applied to group with transform (grid.define/grid.use)
+  # alpha mask applied to group with transform (grid.define/grid.use):
+  # mask must be on a wrapper <g> (no transform) and not on the transform <g>
+  # so that mask coordinates resolve in the parent coordinate space
   x_u <- xmlSVG({
     grid.newpage()
     grid.define(rectGrob(gp = gpar(col = NA, fill = "blue")), name = "box")
     grid.use("box", vp = viewport(mask = mask))
   })
   g_node <- xml_find_first(x_u, ".//g[contains(@style,'transform:matrix')]")
-  expect_equal(xml_attr(g_node, "mask"), "url(#mask-0)")
+  expect_true(is.na(xml_attr(g_node, "mask")))
+  expect_equal(xml_attr(xml_parent(g_node), "mask"), "url(#mask-0)")
 })


### PR DESCRIPTION
* When a mask is active, `svg_use_group()` was emitting the transform `<g>` and `<use>` without referencing it, leaving the mask as a dead `<defs>` entry.
* With a transform: now add mask attribute to the transform `<g>` so the mask is applied in page coordinate space (before the transform).
* Without a transform: now add mask attribute directly to the `<use>` element.
* Note it is possible in both cases to instead apply the mask as a separate `<g>` but this would result in larger svg files.
* Disclaimer: Claude Code assisted in writing this patch but I've manually reviewed each line of code and edited the code it produced.
* For testing I did the following:
 
  + added some new tests as `tests/testthat/test-use-group.R` 
  + manually confirmed this solves the reprexes reported in #206 
  + I also installed this version of {svglite} to my machine and made sure this didn't change any of several affine transformation snapshots in {piecepackr} that directly use {svglite} as a writer
    
closes #206
